### PR TITLE
Supporting syncCto

### DIFF
--- a/src/system/modules/theme_plus/languages/de/tl_syncCto_database.php
+++ b/src/system/modules/theme_plus/languages/de/tl_syncCto_database.php
@@ -1,0 +1,15 @@
+<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+
+/**
+ * Contao Open Source CMS
+ *
+ * @copyright  MEN AT WORK 2013 
+ * @package    syncCto
+ * @license    GNU/LGPL 
+ * @filesource
+ */
+
+$GLOBALS['TL_LANG']['tl_syncCto_database']['tl_theme_plus_file']             = 'Theme+ Dateien';
+$GLOBALS['TL_LANG']['tl_syncCto_database']['tl_theme_plus_variable']         = 'Theme+ Variablen';
+
+?>

--- a/src/system/modules/theme_plus/languages/en/tl_syncCto_database.php
+++ b/src/system/modules/theme_plus/languages/en/tl_syncCto_database.php
@@ -1,0 +1,15 @@
+<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+
+/**
+ * Contao Open Source CMS
+ *
+ * @copyright  MEN AT WORK 2013 
+ * @package    syncCto
+ * @license    GNU/LGPL 
+ * @filesource
+ */
+
+$GLOBALS['TL_LANG']['tl_syncCto_database']['tl_theme_plus_file']             = 'Theme+ files';
+$GLOBALS['TL_LANG']['tl_syncCto_database']['tl_theme_plus_variable']         = 'Theme+ variables';
+
+?>


### PR DESCRIPTION
Theme+ unterstützt damit das neueste Feature von syncCto: Lesbare Tabellennamen für Redakteure
