### PR TITLE
Palette extension fix

### DIFF
--- a/contao/dca/tl_page.php
+++ b/contao/dca/tl_page.php
@@ -24,7 +24,7 @@ foreach (array('regular', 'forward', 'redirect', 'root') as $strType) {
     $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'theme_plus_include_javascripts_noinherit';
 
     $GLOBALS['TL_DCA']['tl_page']['palettes'][$strType] = preg_replace(
-        '#({layout_legend(:hide)*}.*);#U',
+        '#({layout_legend(:hide)?}.*);#U',
         '$1,theme_plus_include_stylesheets,theme_plus_include_stylesheets_noinherit,theme_plus_include_javascripts,theme_plus_include_javascripts_noinherit;',
         $GLOBALS['TL_DCA']['tl_page']['palettes'][$strType]
     );


### PR DESCRIPTION
On extending tl_page palettes, making the :hide attribute optional as for example in Contao 3.2.7 the palette of the "root" page is only {layout_legend} instead of {layout_legend:hide}
